### PR TITLE
Added API Key authorization to UniversalFeedEndpoint.

### DIFF
--- a/src/Inedo.UPack/Net/DefaultApiTransport.cs
+++ b/src/Inedo.UPack/Net/DefaultApiTransport.cs
@@ -121,8 +121,15 @@ namespace Inedo.UPack.Net
             url += r.RelativeUrl;
 
             var message = new HttpRequestMessage(new HttpMethod(r.Method), url);
-            if (!string.IsNullOrEmpty(r.Endpoint.UserName) && r.Endpoint.Password != null)
+            //default to using API Key if it exists
+            if (!string.IsNullOrEmpty(r.Endpoint.APIKey))
+            {
+                message.Headers.Add("X-ApiKey", r.Endpoint.APIKey);
+            }
+            else if (!string.IsNullOrEmpty(r.Endpoint.UserName) && r.Endpoint.Password != null)
+            {
                 message.Headers.Authorization = new AuthenticationHeaderValue("Basic", GetBasicAuthToken(r.Endpoint.UserName!, r.Endpoint.Password));
+            }
 
             return message;
         }

--- a/src/Inedo.UPack/Net/UniversalFeedEndpoint.cs
+++ b/src/Inedo.UPack/Net/UniversalFeedEndpoint.cs
@@ -72,6 +72,21 @@ namespace Inedo.UPack.Net
             this.UserName = userName;
             this.Password = password ?? throw new ArgumentNullException(nameof(password));
         }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UniversalFeedEndpoint"/> class.
+        /// </summary>
+        /// <param name="uri">The API endpoint URL.</param>
+        /// <param name="apiKey">API Key to use for api key authentication.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="uri"/> is null or <paramref name="apiKey"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="uri"/> is not http or https.</exception>
+        public UniversalFeedEndpoint(Uri uri, string apiKey)
+            : this(uri, false)
+        {
+            if (string.IsNullOrEmpty(apiKey))
+                throw new ArgumentNullException(nameof(apiKey));
+
+            this.APIKey = apiKey;
+        }
 
         /// <summary>
         /// Gets the feed API URL.
@@ -89,6 +104,11 @@ namespace Inedo.UPack.Net
         /// Gets the password for basic authentication.
         /// </summary>
         public SecureString? Password { get; }
+
+        /// <summary>
+        /// Gets the API Key for api key authentication.
+        /// </summary>
+        public string? APIKey { get; }
 
         internal bool IsLocalDirectory => string.Equals(this.Uri.Scheme, "file", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
The UniversalFeedEndpoint can now be instantiated with an APIKey instead of a username and password. Requests from this endpoint will now use the API Key in the message header rather than a basic authorization token.