### PR TITLE
Feature/deconstructors

### DIFF
--- a/src/Inedo.UPack/UniversalPackageDependency.cs
+++ b/src/Inedo.UPack/UniversalPackageDependency.cs
@@ -1,4 +1,6 @@
-﻿namespace Inedo.UPack
+﻿using System.Buffers.Binary;
+
+namespace Inedo.UPack
 {
     /// <summary>
     /// Represents a universal package dependency specification.
@@ -136,6 +138,19 @@
                 else
                     return new UniversalPackageDependency(parts[0], parts[1], UniversalPackageVersionRange.Parse(parts[2]));
             }
+        }
+
+        public void Deconstruct(out string? group, out string name, out UniversalPackageVersionRange versionRange)
+        {
+            group = this.Group;
+            name = this.Name;
+            versionRange = this.VersionRange;
+        }
+
+        public void Deconstruct(out string? group, out string name)
+        {
+            group = this.Group;
+            name = this.Name;
         }
 
         public override string ToString()

--- a/src/Inedo.UPack/UniversalPackageId.cs
+++ b/src/Inedo.UPack/UniversalPackageId.cs
@@ -74,6 +74,15 @@ namespace Inedo.UPack
 
             return new UniversalPackageId(null, s);
         }
+        public void Deconstruct(out string name)
+        {
+            name = this.Name;
+        }
+        public void Deconstruct(out string? group, out string name)
+        {
+            group = this.Group;
+            name = this.Name;
+        }
         /// <summary>
         /// Returns a value indicating whether the specified string is a valid upack group.
         /// </summary>

--- a/src/Inedo.UPack/UniversalPackageVersion.cs
+++ b/src/Inedo.UPack/UniversalPackageVersion.cs
@@ -100,6 +100,27 @@ namespace Inedo.UPack
             var version = ParseInternal(s, out var error);
             return version ?? throw new ArgumentException(error);
         }
+        public void Deconstruct(out BigInteger major, out BigInteger minor, out BigInteger patch, out string? prerelease, out string? build)
+        {
+            major = this.Major;
+            minor = this.Minor;
+            patch = this.Patch;
+            prerelease = this.Prerelease;
+            build = this.Build;
+        }
+        public void Deconstruct(out BigInteger major, out BigInteger minor, out BigInteger patch, out string? prerelease)
+        {
+            major = this.Major;
+            minor = this.Minor;
+            patch = this.Patch;
+            prerelease = this.Prerelease;
+        }
+        public void Deconstruct(out BigInteger major, out BigInteger minor, out BigInteger patch)
+        {
+            major = this.Major;
+            minor = this.Minor;
+            patch = this.Patch;
+        }
         public static bool Equals(UniversalPackageVersion? a, UniversalPackageVersion? b)
         {
             if (ReferenceEquals(a, b))

--- a/src/Inedo.UPack/UniversalPackageVersionRange.cs
+++ b/src/Inedo.UPack/UniversalPackageVersionRange.cs
@@ -154,6 +154,14 @@ namespace Inedo.UPack
             return true;
         }
 
+        public void Deconstruct(out UniversalPackageVersion? lowerBound, out bool lowerExclusive, out UniversalPackageVersion? upperBound, out bool upperExclusive)
+        {
+            lowerBound = this.LowerBound;
+            lowerExclusive = this.LowerExclusive;
+            upperBound = this.UpperBound;
+            upperExclusive = this.UpperExclusive;
+        }
+
         /// <summary>
         /// Determines whether two <see cref="UniversalPackageVersionRange"/> instances are equivalent.
         /// </summary>


### PR DESCRIPTION
This PR adds deconstructors to the primary types making it easier to do switch expressions on them. This would allow doing things like:
```csharp
public static bool ShouldGetPackage(UniversalPackageMetadata meta)
{
    return (meta.Group, meta.Name, meta.Version) switch
    {
        // All our packages have a group set
        (null, _, _) => false,
        // We are not interested in prereleases
        (string, string, (_, _, _, string pre)) when pre.Length > 0 => false,
        // Get any game that is not a prerelease
        ("Games", _, _) => true,
        // Get any utility that is past version 1.0.0
        ("Util", _, UniversalPackageVersion v) when v > new UniversalPackageVersion(1, 0, 0) => true,
        // We are not interested in any other packages
        _ => false,
    };
}
```